### PR TITLE
Fix crash in the visitor implementation

### DIFF
--- a/src/flake8_pydantic/visitor.py
+++ b/src/flake8_pydantic/visitor.py
@@ -28,7 +28,9 @@ class Visitor(ast.NodeVisitor):
         self.class_stack.pop()
 
     @property
-    def current_class(self) -> ClassType:
+    def current_class(self) -> ClassType | None:
+        if not self.class_stack:
+            return None
         return self.class_stack[-1]
 
     def _check_pyd_001(self, node: ast.AnnAssign) -> None:


### PR DESCRIPTION
Fixes #8.

It was assumed to always be inside a class, which isn't true in a lot of cases