### PR TITLE
Ignore non-annotated `model_config` attributes

### DIFF
--- a/src/flake8_pydantic/visitor.py
+++ b/src/flake8_pydantic/visitor.py
@@ -50,6 +50,7 @@ class Visitor(ast.NodeVisitor):
                 if isinstance(assign, ast.Assign)
                 if isinstance(assign.targets[0], ast.Name)
                 if not assign.targets[0].id.startswith("_")
+                if not assign.targets[0].id == "model_config"
             ]
             for assignment in invalid_assignments:
                 self.errors.append(PYD002.from_node(assignment))

--- a/tests/rules/test_pyd002.py
+++ b/tests/rules/test_pyd002.py
@@ -17,6 +17,11 @@ class Model(BaseModel):
     _a = 1
 """
 
+PYD002_MODEL_MODEL_CONFIG = """
+class Model(BaseModel):
+    model_config = {}
+"""
+
 PYD002_DATACLASS = """
 @dataclass
 class Model:
@@ -29,6 +34,7 @@ class Model:
     [
         (PYD002_MODEL, [PYD002(3, 4)]),
         (PYD002_MODEL_PRIVATE_FIELD, []),
+        (PYD002_MODEL_MODEL_CONFIG, []),
         (PYD002_DATACLASS, []),
     ],
 )


### PR DESCRIPTION
Fixes https://github.com/Viicos/flake8-pydantic/issues/14.